### PR TITLE
Update package.json to use @account-kit/react 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@account-kit/core": "^4.0.0",
-    "@account-kit/infra": "^4.0.0",
-    "@account-kit/react": "^4.0.0",
+    "@account-kit/core": "^4.9.0",
+    "@account-kit/infra": "^4.9.0",
+    "@account-kit/react": "^4.9.0",
     "@tanstack/react-query": "^5.50.1",
     "next": "14.2.4",
     "react": "^18",


### PR DESCRIPTION
@account-kit/react 4.9.0 replaces default email auth to OTP to previous magic link